### PR TITLE
Update mmap06 and mmap07 to work with sgx-lkl's mmap implementation

### DIFF
--- a/testcases/kernel/syscalls/mmap/mmap06.c
+++ b/testcases/kernel/syscalls/mmap/mmap06.c
@@ -26,10 +26,11 @@
  *  The call should fail to map the file.
  *
  * Expected Result:
- *  mmap() should fail returning -1 and errno should get set to EACCES.
+ *  mmap() should fail returning -1 and errno should get set to EBADF.
  *
  * HISTORY
  *	07/2001 Ported by Wayne Boyer
+ *	07/2020 Modified for sgx-lkl to check EBADF rather than EACCES
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -89,8 +90,8 @@ int main(int ac, char **av)
 			}
 			continue;
 		}
-		if (TEST_ERRNO == EACCES) {
-			tst_resm(TPASS, "mmap failed with EACCES");
+		if (TEST_ERRNO == EBADF) {
+			tst_resm(TPASS, "mmap failed with EBADF");
 		} else {
 			tst_resm(TFAIL | TERRNO,
 				 "mmap failed with unexpected errno");

--- a/testcases/kernel/syscalls/mmap/mmap07.c
+++ b/testcases/kernel/syscalls/mmap/mmap07.c
@@ -27,10 +27,11 @@
  *  The call should fail to map the file.
  *
  * Expected Result:
- *  mmap() should fail returning -1 and errno should get set to EACCES.
+ *  mmap() should fail returning -1 and errno should get set to EBADF.
  *
  * HISTORY
  *	07/2001 Ported by Wayne Boyer
+ *	07/2020 Modifed for sgx-lkl to check for EBADF rather than EACCES
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -90,8 +91,8 @@ int main(int ac, char **av)
 			}
 			continue;
 		}
-		if (TEST_ERRNO == EACCES) {
-			tst_resm(TPASS, "mmap failed with EACCES");
+		if (TEST_ERRNO == EBADF) {
+			tst_resm(TPASS, "mmap failed with EBADF");
 		} else {
 			tst_resm(TFAIL | TERRNO,
 				 "mmap failed with unexpected errno");


### PR DESCRIPTION
As part of changing sgx-lkl to only use it's internal mmap implementation,
we lost the ability to distinguish between EBADF and EACCES errors that
mmap06, mmap07, and mmap08 were testing the distinction between.

Overall, the corresponding sgx-lkl change is a win as it removes a source
of subtle bugs. A corresponding issue for sgx-lkl is open to track this
discrepancy in the mmap API so that in the future, these changes could
be reverted.