### PR TITLE
LTP: Fixed fallocate01&03, lgetxattr02, preadv203

### DIFF
--- a/testcases/kernel/syscalls/preadv2/preadv203.c
+++ b/testcases/kernel/syscalls/preadv2/preadv203.c
@@ -35,6 +35,18 @@
  *
  */
 
+/*
+ * Patch Description:
+ * Failure reason in SGX-LKL:
+ *[[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/preadv2/preadv203
+ [    0.143012] Out of memory: Killed process 36 (host0) total-vm:4kB, anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
+ [    0.144073] Kernel panic - not syncing: System is deadlocked on memory
+ *
+ * Work around to fix the issue:
+ * Tests were failing with kernel panic in loop device as loop device is having 32MB memory limit
+ * So modified the tests to use root filesystem.
+ */
+
 #define _GNU_SOURCE
 #include <string.h>
 #include <sys/uio.h>
@@ -240,6 +252,8 @@ static void check_preadv2_nowait(int fd)
 
 static void setup(void)
 {
+	rmdir(MNTPOINT);
+        SAFE_MKDIR(MNTPOINT, 0644);
 	char path[1024];
 	char buf[CHUNK_SZ];
 	unsigned int i;
@@ -263,11 +277,15 @@ static void setup(void)
 static void do_cleanup(void)
 {
 	unsigned int i;
-
+	char path[1024];
 	for (i = 0; i < FILES; i++) {
+		snprintf(path, sizeof(path), MNTPOINT"/file_%i", i);
 		if (fds[i] > 0)
 			SAFE_CLOSE(fds[i]);
+		remove(path);
 	}
+
+	SAFE_RMDIR(MNTPOINT);
 }
 
 TST_DECLARE_ONCE_FN(cleanup, do_cleanup);
@@ -276,9 +294,5 @@ static struct tst_test test = {
 	.setup = setup,
 	.cleanup = cleanup,
 	.test_all = verify_preadv2,
-	.mntpoint = MNTPOINT,
-	.mount_device = 1,
-	.all_filesystems = 1,
-	.needs_tmpdir = 1,
 	.needs_root = 1,
 };


### PR DESCRIPTION
 Patch Description: 
 * Test Failure reason in SGX-LKL: 
 * [[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/fallocate/fallocate01
 * fallocate01    1  TCONF  :  fallocate01.c:233: fallocate system call is not implemented

 * Workaround to fix the issue:
 * fallocate system call is failing on temporary file created under /tmp directory.
 * So modified the tests to create directory in root filesystem.

Patch Description:
 * Test Failure reason in SGX-LKL:
 * [[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/fallocate/fallocate03
 * fallocate03    1  TCONF  :  fallocate03.c:251: fallocate system call is not implemented
 
 * Workaround to fix the issue:
 * fallocate system call is failing on temporary file created under /tmp directory.
 * So modified the tests to create directory in root filesystem.

Patch Description:
 * Test failure reason in SGX-LKL:
 * [[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
 * tst_test.c:1106: INFO: Timeout per run is 0h 05m 00s
 * tst_test.c:1125: INFO: No fork support
 * lgetxattr02.c:78: CONF: no xattr support in fs or mounted without user_xattr option
 
 * Workaround to fix the issue:
 * Modified the tests to use root filesystem.
 * Commented a test, which needs to be enabled once git issue 297 is fixed
 * Issue 297: [Tests] lkl_access_ok() should return -1 on invalid access
 * https://github.com/lsds/sgx-lkl/issues/297

Patch Description:
 * Failure reason in SGX-LKL:
 *[[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/preadv2/preadv203
 [    0.143012] Out of memory: Killed process 36 (host0) total-vm:4kB, anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
 [    0.144073] Kernel panic - not syncing: System is deadlocked on memory
 
 * Work around to fix the issue:
 * Tests were failing with kernel panic in loop device as loop device is having 32MB memory limit
 * So modified the tests to use root filesystem.