### PR TITLE
LTP: Fixed lgetxattr02 testcase

### DIFF
--- a/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
+++ b/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
@@ -21,17 +21,15 @@
 
 /*
  * Patch Description:
- * Test failure reason in SGX-LKL:
- * [[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
- * tst_test.c:1106: INFO: Timeout per run is 0h 05m 00s
- * tst_test.c:1125: INFO: No fork support
- * lgetxattr02.c:78: CONF: no xattr support in fs or mounted without user_xattr option
- *
+    Test failure reason in SGX-LKL:
+    [[ SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
+    tst_test.c:1106: INFO: Timeout per run is 0h 05m 00s
+    tst_test.c:1125: INFO: No fork support
+    lgetxattr02.c:78: CONF: no xattr support in fs or mounted without user_xattr option
+
  * Workaround to fix the issue:
- * Modified the tests to use root filesystem.
- * Commented a test, which needs to be enabled once git issue 297 is fixed
- * Issue 297: [Tests] lkl_access_ok() should return -1 on invalid access
- * https://github.com/lsds/sgx-lkl/issues/297
+    Modified the tests to use root filesystem.
+    Disabled a test, which needs to be enabled once git issue lsds/sgx-lkl#297 is fixed
  */
 
 #include "config.h"
@@ -49,7 +47,7 @@
 
 #define SECURITY_KEY	"security.ltptest"
 #define VALUE	"this is a test value"
-#define tmpdir  "/tmplgetxattr"
+
 static struct test_case {
 	const char *path;
 	size_t size;
@@ -82,7 +80,7 @@ static void verify_lgetxattr(unsigned int n)
 static void setup(void)
 {
 	int res;
-	SAFE_MKDIR(tmpdir, 0644);
+
 	SAFE_TOUCH("testfile", 0644, NULL);
 	SAFE_SYMLINK("testfile", "symlink");
 
@@ -102,7 +100,6 @@ void cleanup(void)
 {
         remove("testfile");
         remove("symlink");
-        SAFE_RMDIR(tmpdir);
 }
 
 static struct tst_test test = {

--- a/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
+++ b/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
@@ -26,7 +26,6 @@
 
  * Workaround to fix the issue:
     Modified the tests to use root filesystem.
-    Disabled a test, which needs to be enabled once git issue lsds/sgx-lkl#297 is fixed
  */
 
 #include "config.h"
@@ -52,7 +51,7 @@ static struct test_case {
 } tcase[] = {
 	{"testfile", sizeof(VALUE), ENODATA},
 	{"symlink", 1, ERANGE},
-//	{(char *)-1, sizeof(VALUE), EFAULT} TODO: Enable once git issue 297 is fixed
+	{(char *)-1, sizeof(VALUE), EFAULT}
 };
 
 static void verify_lgetxattr(unsigned int n)

--- a/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
+++ b/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
@@ -100,7 +100,11 @@ void cleanup(void)
 }
 
 static struct tst_test test = {
-	// Removed directory creation and mounting tmp filesystem
+	// .needs_tmpdir = 1 creates a test directory mounting /tmp filesystem
+	// commented this line, so that temporary directory will be not created becuase
+	// the test is failing with no xattr support. Now the files will be directly 
+	// created in the root filesystem.
+	// .needs_tmpdir = 1,
 	.needs_root = 1,
 	.test = verify_lgetxattr,
 	.tcnt = ARRAY_SIZE(tcase),

--- a/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
+++ b/testcases/kernel/syscalls/lgetxattr/lgetxattr02.c
@@ -22,10 +22,7 @@
 /*
  * Patch Description:
     Test failure reason in SGX-LKL:
-    [[ SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
-    tst_test.c:1106: INFO: Timeout per run is 0h 05m 00s
-    tst_test.c:1125: INFO: No fork support
-    lgetxattr02.c:78: CONF: no xattr support in fs or mounted without user_xattr option
+    Tests were failing with no user_xattr support in tmp filesystem.
 
  * Workaround to fix the issue:
     Modified the tests to use root filesystem.
@@ -103,6 +100,7 @@ void cleanup(void)
 }
 
 static struct tst_test test = {
+	// Removed directory creation and mounting tmp filesystem
 	.needs_root = 1,
 	.test = verify_lgetxattr,
 	.tcnt = ARRAY_SIZE(tcase),


### PR DESCRIPTION
* Patch Description:
  Test failure reason in SGX-LKL:
  [[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
  tst_test.c:1106: INFO: Timeout per run is 0h 05m 00s
  tst_test.c:1125: INFO: No fork support
  lgetxattr02.c:78: CONF: no xattr support in fs or mounted without user_xattr option
 
 * Workaround to fix the issue:
  Modified the tests to use root filesystem.
  Disabled a test, which needs to be enabled once git issue https://github.com/lsds/sgx-lkl/issues/297 is fixed
