### PR TITLE
Revert test conditions in setresuid and setreuid to match upstream

### DIFF
--- a/testcases/kernel/syscalls/setresuid/setresuid04.c
+++ b/testcases/kernel/syscalls/setresuid/setresuid04.c
@@ -98,12 +98,13 @@ void *do_sub_thread(void* arg)
 	TEST(tst_fd2 = open(testfile, O_RDWR));
 
 	if (TEST_RETURN != -1) {
-		tst_resm(TPASS,
-			"open call succeeded as expected in thread2");
-		close(tst_fd2);
+	        close(tst_fd2);
+                tst_brkm(TBROK, cleanup, "open succeeded unexpectedly\n");
+        }
+	if (TEST_ERRNO == EACCES) {
+                tst_resm(TPASS, "open failed with EACCES as expected\n");
 	} else {
-		tst_brkm(TBROK, cleanup,
-			"open failed unexpectedly in thread2\n");
+		tst_brkm(TBROK, cleanup, "open failed unexpectedly in thread2\n");
 	}
 	pthread_exit(NULL);
 }

--- a/testcases/kernel/syscalls/setreuid/setreuid07.c
+++ b/testcases/kernel/syscalls/setreuid/setreuid07.c
@@ -79,11 +79,11 @@ static void *do_sub_thread(void* arg)
 	TEST(tst_fd2 = open(testfile, O_RDWR));
 
 	if (TEST_RETURN != -1) {
-		tst_resm(TPASS,
-			"open call succeeded as expected in thread2");
-	} else {
-		tst_brkm(TBROK, cleanup,
-			"open failed unexpectedly in thread2");
+		tst_brkm(TBROK, cleanup, "call succeeded unexpectedly");
+	} if (TEST_ERRNO == EACCES) {
+                tst_resm(TPASS, "open failed with EACCES as expected");
+        } else {
+		tst_brkm(TBROK, cleanup, "open failed unexpectedly in thread2");
 	}
 	if (tst_fd2 >= 0)
 		close(tst_fd2);


### PR DESCRIPTION
### Summary
`setreuid07` and `setresuid04` tests check scenarios related to user permisions. Specifically if file created in the parent process can be opened in its child processes by user `nobody`. The version of these tests in ltp `20190930` pass only if the child proceses are unable to open the file, and `open` returns with errno `EACCES`. The existing patch changed the behavior by making the test pass even if the was successfully being opened. It looks like this was done to make the test pass and comply with the behavior of sgx-lkl `oe_port`.
With sgx-lkl [PR# 403](https://github.com/lsds/sgx-lkl/pull/403), the behavior related to setreuid and setresuid has changed. Hence, this PR to revert the previous patch and make the test conditions consistent with ltp `20190930`.