### PR TITLE
LTP: fix test case fchown04 issue

### DIFF
--- a/testcases/kernel/syscalls/fchown/fchown04.c
+++ b/testcases/kernel/syscalls/fchown/fchown04.c
@@ -61,7 +61,9 @@ static struct test_case_t {
 } test_cases[] = {
 	{&fd1, EPERM},
 	{&fd2, EBADF},
-	{&fd3, EROFS},
+// This test is commented because there is
+// no read-only file system mounted on sgx-lkl.
+//	{&fd3, EROFS},
 };
 
 TCID_DEFINE(fchown04);
@@ -103,16 +105,23 @@ static void setup(void)
 
 	tst_tmpdir();
 
+// This code is disabled because it explicitly
+// acquire a loop device to mount the fs.
+#if 0
 	fs_type = tst_dev_fs_type();
 	device = tst_acquire_device(cleanup);
 
 	if (!device)
 		tst_brkm(TCONF, cleanup, "Failed to acquire device");
+#endif
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
 	fd1 = SAFE_OPEN(cleanup, "tfile_1", O_RDWR | O_CREAT, 0666);
 
+// This code is disabled because it explicitly
+// create a filesystem using mkfs on the loop device and mount the fs.
+#if 0
 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
 	SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
 	SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL);
@@ -121,6 +130,7 @@ static void setup(void)
 	SAFE_MOUNT(cleanup, device, "mntpoint", fs_type,
 		   MS_REMOUNT | MS_RDONLY, NULL);
 	fd3 = SAFE_OPEN(cleanup, "mntpoint/tfile_3", O_RDONLY);
+#endif
 
 	ltpuser = SAFE_GETPWNAM(cleanup, "nobody");
 	SAFE_SETEUID(cleanup, ltpuser->pw_uid);
@@ -155,6 +165,10 @@ static void cleanup(void)
 	if (fd1 > 0 && close(fd1))
 		tst_resm(TWARN | TERRNO, "Failed to close fd1");
 
+// This code performs clean up of mounted filesystem and disabled sub test case.
+// This code is not needed because mounting filesystem and sub test case is
+// disabled. Hence, disabling this code.
+#if 0
 	if (fd3 > 0 && close(fd3))
 		tst_resm(TWARN | TERRNO, "Failed to close fd3");
 
@@ -163,6 +177,7 @@ static void cleanup(void)
 
 	if (device)
 		tst_release_device(device);
+#endif
 
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/fchown/fchown04.c
+++ b/testcases/kernel/syscalls/fchown/fchown04.c
@@ -28,7 +28,6 @@
  *   3) fchown(2) returns -1 and sets errno to EROFS if the named file resides
  *	on a read-only file system.
  */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -41,6 +40,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mount.h>
+#include <linux/loop.h>
+#include <sys/ioctl.h>
 
 #include "test.h"
 #include "safe_macros.h"
@@ -61,9 +62,7 @@ static struct test_case_t {
 } test_cases[] = {
 	{&fd1, EPERM},
 	{&fd2, EBADF},
-// This test is commented because there is
-// no read-only file system mounted on sgx-lkl.
-//	{&fd3, EROFS},
+	{&fd3, EROFS},
 };
 
 TCID_DEFINE(fchown04);
@@ -72,6 +71,7 @@ int TST_TOTAL = ARRAY_SIZE(test_cases);
 static void setup(void);
 static void fchown_verify(int);
 static void cleanup(void);
+char loopname[4096];
 
 int main(int ac, char **av)
 {
@@ -94,6 +94,41 @@ int main(int ac, char **av)
 	tst_exit();
 }
 
+void acquire_device(void)
+{
+        int ctlloopdev, loopdev, fsimgfile;
+        long devnum;
+	
+	// Open loop controle device file	
+	ctlloopdev = open("/dev/loop-control", O_RDWR);
+        if (ctlloopdev == -1)
+        	tst_brkm(TBROK, cleanup, "failed to open /dev/loop-control");
+
+	// Find the free loop device
+	devnum = ioctl(ctlloopdev, LOOP_CTL_GET_FREE);
+        if (devnum == -1)
+        	tst_brkm(TBROK, cleanup, "failed to get free loop device");
+
+	sprintf(loopname, "/dev/loop%ld", devnum);
+	tst_resm(TINFO, "loopname = %s\n", loopname);
+
+	loopdev = open(loopname, O_RDWR);
+        if (loopdev == -1)
+        	tst_brkm(TBROK, cleanup, "failed to open: loop device");
+
+	fsimgfile = open("/ltp_tst_mnt_fs/tstfs_ext4.img", O_RDWR);
+        if (fsimgfile == -1)
+        	tst_brkm(TBROK, cleanup, "failed to open: file system image file");
+
+        if (ioctl(loopdev, LOOP_SET_FD, fsimgfile) == -1)
+               tst_brkm(TBROK, cleanup, "failed to set loop fd");
+	
+	close(fsimgfile);
+    	close(loopdev);
+	
+
+}
+
 static void setup(void)
 {
 	struct passwd *ltpuser;
@@ -107,21 +142,18 @@ static void setup(void)
 
 // This code is disabled because it explicitly
 // acquire a loop device to mount the fs.
+// create a filesystem using mkfs on the loop device and mount the fs.
 #if 0
 	fs_type = tst_dev_fs_type();
 	device = tst_acquire_device(cleanup);
 
 	if (!device)
 		tst_brkm(TCONF, cleanup, "Failed to acquire device");
-#endif
 
 	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 
 	fd1 = SAFE_OPEN(cleanup, "tfile_1", O_RDWR | O_CREAT, 0666);
 
-// This code is disabled because it explicitly
-// create a filesystem using mkfs on the loop device and mount the fs.
-#if 0
 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
 	SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
 	SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL);
@@ -131,6 +163,22 @@ static void setup(void)
 		   MS_REMOUNT | MS_RDONLY, NULL);
 	fd3 = SAFE_OPEN(cleanup, "mntpoint/tfile_3", O_RDONLY);
 #endif
+	tst_sig(NOFORK, DEF_HANDLER, cleanup);
+
+	fd1 = SAFE_OPEN(cleanup, "tfile_1", O_RDWR | O_CREAT, 0666);
+
+	acquire_device();
+
+	// Create mount point and mount the loop device
+	SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
+	SAFE_MOUNT(cleanup, loopname, "mntpoint", "ext4", 0, NULL);
+
+	// create a test file and remout the filesystem in Read only mode
+	mount_flag = 1;
+	SAFE_TOUCH(cleanup, "mntpoint/tfile_3", 0644, NULL);
+	SAFE_MOUNT(cleanup, loopname, "mntpoint", "ext4",
+		   MS_REMOUNT | MS_RDONLY, NULL);
+	fd3 = SAFE_OPEN(cleanup, "mntpoint/tfile_3", O_RDONLY);
 
 	ltpuser = SAFE_GETPWNAM(cleanup, "nobody");
 	SAFE_SETEUID(cleanup, ltpuser->pw_uid);
@@ -178,6 +226,15 @@ static void cleanup(void)
 	if (device)
 		tst_release_device(device);
 #endif
+        if (fd3 > 0 && close(fd3))
+                tst_resm(TWARN | TERRNO, "Failed to close fd3");
+	if (mount_flag) {
+		int devfd = open(loopname, O_RDWR);
+		if (ioctl(devfd, LOOP_CLR_FD, 0) < 0) {
+    			tst_resm(TWARN | TERRNO, "Failed to clear fd");
+		}
+		SAFE_UMOUNT(cleanup, "mntpoint");
+	}
 
 	tst_rmdir();
 }


### PR DESCRIPTION
The original test case performs the below tests:
1) fchown(2) returns -1 and sets errno to EPERM if the effective
   user id of the process does not match the owner of the file
   and the process is not a superuser.
2) fchown(2) returns -1 and sets errno to EBADF if the file
   descriptor of the specified file is not valid.
3) fchown(2) returns -1 and sets errno to EROFS if the named file
   resides on a read-only file system.

Problem/issue:
This test case causing oom killer to be invoked and causing
kernel panic. This is because the test case invokes test framework
function "tst_acquire_device" which creates a 256MB of .img file
and binds with a loop device.  This is not supported because the
default size of LKL memory is set to 32M. This is kept low due to
the limited size of EPC (Enclave page cache) and to avoid page
cache being swapped out.
Also, the test case invokes "tst_mkfs" framework function which
inturn invokes mkfs utility command with the help of system() syscall.
It is recommended to use root file system, but, this test case
needs a read-only filesystem to test one of the sub-test case.
we don't have a read-only file system mounted in sgx-lkl.
Hence, disabling the code related to the mount and sub test case.

Modifications:
 1. Disable the 3rd subtest case
 2. Disable the code which creates file system, mount, and unmount the filesystem.
Review-1:
 1. Added the code to create a loop device and mount. This need some changes to lsds/sgx-lkl repo, new PR is raised https://github.com/lsds/sgx-lkl/pull/764
 2. Enabled the 3rd sub test case.
 
 
