### PR TITLE
LTP: fix test case mount04&06 issue

### DIFF
--- a/testcases/kernel/syscalls/mount/mount04.c
+++ b/testcases/kernel/syscalls/mount/mount04.c
@@ -22,6 +22,7 @@
 #include <sys/mount.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <linux/loop.h>
 #include <fcntl.h>
 #include <pwd.h>
 #include "test.h"
@@ -35,10 +36,50 @@ char *TCID = "mount04";
 #define DIR_MODE	S_IRWXU | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP
 
 static char *mntpoint = "mntpoint";
-static const char *fs_type;
-static const char *device;
+static const char fs_type[256] = "ext4";
+static const char device[1024];
+int loopdev_flag = 0;
 
 int TST_TOTAL = 1;
+
+// acquire_device: find free loop device and bind the
+// filesystem image with it.
+void acquire_device(void)
+{
+        int ctlloopdev, loopdev, fsimgfile;
+        long devnum;
+
+	// Open loop controle device file	
+	ctlloopdev = open("/dev/loop-control", O_RDWR);
+        if (ctlloopdev == -1)
+        	tst_brkm(TBROK, cleanup, "failed to open /dev/loop-control");
+
+	// Find the free loop device
+	devnum = ioctl(ctlloopdev, LOOP_CTL_GET_FREE);
+        if (devnum == -1)
+        	tst_brkm(TBROK, cleanup, "failed to get free loop device");
+
+	sprintf(device, "/dev/loop%ld", devnum);
+	tst_resm(TINFO, "device = %s\n", device);
+
+	// Open a loop device
+	loopdev = open(device, O_RDWR);
+        if (loopdev == -1)
+        	tst_brkm(TBROK, cleanup, "failed to open: loop device");
+
+	// open a filesystem image
+	fsimgfile = open("/ltp_tst_mnt_fs/tstfs_ext4.img", O_RDWR);
+        if (fsimgfile == -1)
+        	tst_brkm(TBROK, cleanup, "failed to open: file system image file");
+
+	// bind filesystem image loop device
+        if (ioctl(loopdev, LOOP_SET_FD, fsimgfile) == -1)
+               tst_brkm(TBROK, cleanup, "failed to set loop fd");
+
+	close(fsimgfile);
+    	close(loopdev);
+	loopdev_flag = 1;
+}
 
 static void verify_mount(void)
 {
@@ -92,6 +133,9 @@ static void setup(void)
 
 	tst_tmpdir();
 
+// Framework code causing the oom killer issue
+// Hence, Removed the code.
+#if 0
 	fs_type = tst_dev_fs_type();
 	device = tst_acquire_device(cleanup);
 
@@ -99,6 +143,9 @@ static void setup(void)
 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
 
 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+#endif
+	
+	acquire_device();
 
 	ltpuser = SAFE_GETPWNAM(cleanup, nobody_uid);
 	SAFE_SETEUID(cleanup, ltpuser->pw_uid);
@@ -112,8 +159,19 @@ static void cleanup(void)
 	if (seteuid(0))
 		tst_resm(TWARN | TERRNO, "seteuid(0) failed");
 
+// Framework code causing the oom killer issue
+// Hence, Removed the code.
+#if 0
 	if (device)
 		tst_release_device(device);
+#endif
+	if (loopdev_flag == 1) {
+		int devfd = open(device, O_RDWR);
+		if (ioctl(devfd, LOOP_CLR_FD, 0) < 0) {
+    			tst_resm(TWARN | TERRNO, "Failed to clear fd");
+		}
+		close(devfd);
+	}
 
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/mount/mount04.c
+++ b/testcases/kernel/syscalls/mount/mount04.c
@@ -22,7 +22,6 @@
 #include <sys/mount.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <linux/loop.h>
 #include <fcntl.h>
 #include <pwd.h>
 #include "test.h"
@@ -36,50 +35,10 @@ char *TCID = "mount04";
 #define DIR_MODE	S_IRWXU | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP
 
 static char *mntpoint = "mntpoint";
-static const char fs_type[256] = "ext4";
-static const char device[1024];
-int loopdev_flag = 0;
+static const char *fs_type;
+static const char *device;
 
 int TST_TOTAL = 1;
-
-// acquire_device: find free loop device and bind the
-// filesystem image with it.
-void acquire_device(void)
-{
-        int ctlloopdev, loopdev, fsimgfile;
-        long devnum;
-
-	// Open loop controle device file	
-	ctlloopdev = open("/dev/loop-control", O_RDWR);
-        if (ctlloopdev == -1)
-        	tst_brkm(TBROK, cleanup, "failed to open /dev/loop-control");
-
-	// Find the free loop device
-	devnum = ioctl(ctlloopdev, LOOP_CTL_GET_FREE);
-        if (devnum == -1)
-        	tst_brkm(TBROK, cleanup, "failed to get free loop device");
-
-	sprintf(device, "/dev/loop%ld", devnum);
-	tst_resm(TINFO, "device = %s\n", device);
-
-	// Open a loop device
-	loopdev = open(device, O_RDWR);
-        if (loopdev == -1)
-        	tst_brkm(TBROK, cleanup, "failed to open: loop device");
-
-	// open a filesystem image
-	fsimgfile = open("/ltp_tst_mnt_fs/tstfs_ext4.img", O_RDWR);
-        if (fsimgfile == -1)
-        	tst_brkm(TBROK, cleanup, "failed to open: file system image file");
-
-	// bind filesystem image loop device
-        if (ioctl(loopdev, LOOP_SET_FD, fsimgfile) == -1)
-               tst_brkm(TBROK, cleanup, "failed to set loop fd");
-
-	close(fsimgfile);
-    	close(loopdev);
-	loopdev_flag = 1;
-}
 
 static void verify_mount(void)
 {
@@ -133,9 +92,6 @@ static void setup(void)
 
 	tst_tmpdir();
 
-// Framework code causing the oom killer issue
-// Hence, Removed the code.
-#if 0
 	fs_type = tst_dev_fs_type();
 	device = tst_acquire_device(cleanup);
 
@@ -143,9 +99,6 @@ static void setup(void)
 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
 
 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
-#endif
-	
-	acquire_device();
 
 	ltpuser = SAFE_GETPWNAM(cleanup, nobody_uid);
 	SAFE_SETEUID(cleanup, ltpuser->pw_uid);
@@ -159,19 +112,8 @@ static void cleanup(void)
 	if (seteuid(0))
 		tst_resm(TWARN | TERRNO, "seteuid(0) failed");
 
-// Framework code causing the oom killer issue
-// Hence, Removed the code.
-#if 0
 	if (device)
 		tst_release_device(device);
-#endif
-	if (loopdev_flag == 1) {
-		int devfd = open(device, O_RDWR);
-		if (ioctl(devfd, LOOP_CLR_FD, 0) < 0) {
-    			tst_resm(TWARN | TERRNO, "Failed to clear fd");
-		}
-		close(devfd);
-	}
 
 	tst_rmdir();
 }

--- a/testcases/kernel/syscalls/mount/mount04.c
+++ b/testcases/kernel/syscalls/mount/mount04.c
@@ -98,7 +98,9 @@ static void setup(void)
 	if (!device)
 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
 
-	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+	// This function use system syscall which is not suported
+	// is sgx-lkl. Github issue https://github.com/lsds/sgx-lkl/issues/598 
+	//tst_mkfs(cleanup, device, fs_type, NULL, NULL);
 
 	ltpuser = SAFE_GETPWNAM(cleanup, nobody_uid);
 	SAFE_SETEUID(cleanup, ltpuser->pw_uid);

--- a/testcases/kernel/syscalls/mount/mount06.c
+++ b/testcases/kernel/syscalls/mount/mount06.c
@@ -24,7 +24,6 @@
 
 #include <errno.h>
 #include <sys/mount.h>
-#include <linux/loop.h>
 #include <unistd.h>
 #include <fcntl.h>
 
@@ -51,50 +50,12 @@ static void cleanup(void);
 char *TCID = "mount06";
 int TST_TOTAL = 1;
 
-static const char fs_type[256] = "ext4";
-static const char device[1024];
+static const char *fs_type;
+static const char *device;
 static char path_name[PATH_MAX];
 static char mntpoint_src[PATH_MAX];
 static char mntpoint_des[PATH_MAX];
 static int mount_flag;
-int loopdev_flag = 0;
-
-void acquire_device(void)
-{
-        int ctlloopdev, loopdev, fsimgfile;
-        long devnum;
-
-	// Open loop controle device file	
-	ctlloopdev = open("/dev/loop-control", O_RDWR);
-        if (ctlloopdev == -1)
-        	tst_brkm(TBROK, cleanup, "failed to open /dev/loop-control");
-
-	// Find the free loop device
-	devnum = ioctl(ctlloopdev, LOOP_CTL_GET_FREE);
-        if (devnum == -1)
-        	tst_brkm(TBROK, cleanup, "failed to get free loop device");
-
-	sprintf(device, "/dev/loop%ld", devnum);
-	tst_resm(TINFO, "device = %s\n", device);
-
-	// Open loop device
-	loopdev = open(device, O_RDWR);
-        if (loopdev == -1)
-        	tst_brkm(TBROK, cleanup, "failed to open: loop device");
-
-	//open filesystem image
-	fsimgfile = open("/ltp_tst_mnt_fs/tstfs_ext4.img", O_RDWR);
-        if (fsimgfile == -1)
-        	tst_brkm(TBROK, cleanup, "failed to open: file system image file");
-
-	// Link loopdevice fd and image file fd
-	if (ioctl(loopdev, LOOP_SET_FD, fsimgfile) == -1)
-               tst_brkm(TBROK, cleanup, "failed to set loop fd");
-	
-	close(fsimgfile);
-    	close(loopdev);
-	loopdev_flag = 1;
-}
 
 int main(int argc, char *argv[])
 {
@@ -160,18 +121,15 @@ static void setup(void)
 
 	tst_tmpdir();
 
-	// This framework code causing oom killer issue
-	// Hence, removed this code.
-#if 0
 	fs_type = tst_dev_fs_type();
 	device = tst_acquire_device(cleanup);
 
 	if (!device)
 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
 
-	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
-#endif
-	acquire_device();
+	// This function use system syscall which is not suported
+	// is sgx-lkl. Github issue https://github.com/lsds/sgx-lkl/issues/598
+	//tst_mkfs(cleanup, device, fs_type, NULL, NULL);
 
 	if (getcwd(path_name, sizeof(path_name)) == NULL)
 		tst_brkm(TBROK, cleanup, "getcwd failed");
@@ -200,19 +158,8 @@ static void cleanup(void)
 	if (mount_flag && tst_umount(path_name) != 0)
 		tst_resm(TWARN | TERRNO, "umount(2) %s failed", path_name);
 
-	// Framework code causing oom killer issue
-	// Hence, removed this code.
-#if 0
 	if (device)
 		tst_release_device(device);
-#endif
-	if (loopdev_flag) {
-		int devfd = open(device, O_RDWR);
-		if (ioctl(devfd, LOOP_CLR_FD, 0) < 0) {
-    			tst_resm(TWARN | TERRNO, "Failed to clear fd");
-		}
-		close(devfd);
-	}
 
 	tst_rmdir();
 }


### PR DESCRIPTION
Problem/issue:
This test case causing oom killer to be invoked and causing
kernel panic. This is because the test case invokes test framework
function "tst_acquire_device" which creates a 256MB of .img file
and binds with a loop device. This is not supported because the
default size of LKL memory is set to 32M. This is kept low due to
the limited size of EPC (Enclave page cache) and to avoid page
cache being swapped out.
Also, the test case invokes "tst_mkfs" framework function which
inturn invokes mkfs utility command with the help of system() syscall.
It is recommended to use root file system, but, this test case
needs a read-only filesystem to test one of the sub-test case.
we don't have a read-only file system mounted in sgx-lkl.
Hence, disabling the code related to the mount and sub test case.

Modifications:
1.  The tst_mkfs call is doing a system libc call to spawn a child process and run mkfs. We can't do that in a single-process environment. Hence, removed this code. 
2. This needs additional changes related to block device creation which is submitted to lsds/sgx-lkl repo, new PR is raised lsds/sgx-lkl#764
3. This also depends on https://github.com/lsds/ltp/pull/65