### PR TITLE
LTP: Use the block device from config file

### DIFF
--- a/include/old/ltp_priv.h
+++ b/include/old/ltp_priv.h
@@ -34,7 +34,7 @@
 /*
  * Default filesystem to be used for tests.
  */
-#define DEFAULT_FS_TYPE "ext2"
+#define DEFAULT_FS_TYPE "ext4"
 
 /* environment variables for controlling  tst_res verbosity */
 #define TOUT_VERBOSE_S  "VERBOSE"	/* All test cases reported */

--- a/lib/tst_device.c
+++ b/lib/tst_device.c
@@ -226,6 +226,7 @@ const char *tst_acquire_device__(unsigned int size)
 {
 	int fd;
 	char *dev;
+	char *dev_mnt;
 	struct stat st;
 	unsigned int acq_dev_size;
 	uint64_t ltp_dev_size;
@@ -274,6 +275,9 @@ const char *tst_acquire_device__(unsigned int size)
 
 		tst_resm(TINFO, "Skipping $LTP_DEV size %"PRIu64"MB, requested size %uMB",
 				ltp_dev_size, acq_dev_size);
+	}
+	else {
+		tst_resm(TWARN, "Block device path is not found in envirinment parameter LTP_DEV");
 	}
 
 	if (tst_fill_file(DEV_FILE, 0, 1024 * 1024, acq_dev_size)) {

--- a/lib/tst_supported_fs_types.c
+++ b/lib/tst_supported_fs_types.c
@@ -32,6 +32,10 @@ static int has_mkfs(const char *fs_type)
 	char buf[128];
 	int ret;
 
+	tst_res(TINFO, "has_mkfs: system() syscall not supported, always return 1");
+
+// TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
+#if 0
 	sprintf(buf, "mkfs.%s >/dev/null 2>&1", fs_type);
 
 	ret = tst_system(buf);
@@ -42,6 +46,7 @@ static int has_mkfs(const char *fs_type)
 	}
 
 	tst_res(TINFO, "mkfs.%s does exist", fs_type);
+#endif
 	return 1;
 }
 

--- a/lib/tst_test.c
+++ b/lib/tst_test.c
@@ -791,7 +791,12 @@ static void do_setup(int argc, char *argv[])
 
 	if (tst_test->mount_device) {
 		tst_test->needs_device = 1;
-		tst_test->format_device = 1;
+               // keep format device is disabled
+               // system() call is not supported. Hence, cannot format to filesystem
+               // . The block device is preformatted to ext4 at compilation
+               // and shared the details with enclave as an environment variable.
+	       // TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
+		tst_test->format_device = 0;
 	}
 
 	if (tst_test->all_filesystems)
@@ -840,7 +845,12 @@ static void do_setup(int argc, char *argv[])
 			tst_res(TINFO, "Can't mount tmpfs read-only, "
 			        "falling back to block device...");
 			tst_test->needs_device = 1;
-			tst_test->format_device = 1;
+               // Disable formating of block device.
+               // system() call is not supported. Hence, cannot format to filesystem
+               // The block device is preformatted to ext4 at compilation
+               // and shared the details with enclave as an environment variable.
+	       // TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
+			tst_test->format_device = 0;
 		}
 	}
 
@@ -1150,7 +1160,13 @@ static int run_tcases_per_fs(void)
 
 	for (i = 0; filesystems[i]; i++) {
 
-		tst_res(TINFO, "Testing on %s", filesystems[i]);
+		// skip test for all fs types except ext4.
+		// system() call is not supported. Hence, cannot format to filesystem
+		// other than ext4. The block device is preformatted at compilation
+		// and shared the details with enclave as an environment variable.
+	       // TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
+		if (strcmp(filesystems[i], "ext4"))
+			continue;
 		tdev.fs_type = filesystems[i];
 
 		prepare_device();

--- a/lib/tst_test.c
+++ b/lib/tst_test.c
@@ -791,11 +791,11 @@ static void do_setup(int argc, char *argv[])
 
 	if (tst_test->mount_device) {
 		tst_test->needs_device = 1;
-               // keep format device is disabled
-               // system() call is not supported. Hence, cannot format to filesystem
-               // . The block device is preformatted to ext4 at compilation
-               // and shared the details with enclave as an environment variable.
-	       // TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
+		// keep format device is disabled
+		// system() call is not supported. Hence, cannot format to filesystem
+		// The block device is preformatted to ext4 at compilation
+		// and shared the details with enclave as an environment variable
+		// TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
 		tst_test->format_device = 0;
 	}
 
@@ -845,11 +845,12 @@ static void do_setup(int argc, char *argv[])
 			tst_res(TINFO, "Can't mount tmpfs read-only, "
 			        "falling back to block device...");
 			tst_test->needs_device = 1;
-               // Disable formating of block device.
-               // system() call is not supported. Hence, cannot format to filesystem
-               // The block device is preformatted to ext4 at compilation
-               // and shared the details with enclave as an environment variable.
-	       // TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
+			// Disable formating of block device.
+			// system() call is not supported. Hence, cannot format to filesystem
+			// The block device is preformatted to ext4 at compilation
+			// and shared the details with enclave as an environment variable
+			// TODO: Enable below code after fixing Github
+			// issue https://github.com/lsds/sgx-lkl/issues/598
 			tst_test->format_device = 0;
 		}
 	}
@@ -1163,8 +1164,8 @@ static int run_tcases_per_fs(void)
 		// skip test for all fs types except ext4.
 		// system() call is not supported. Hence, cannot format to filesystem
 		// other than ext4. The block device is preformatted at compilation
-		// and shared the details with enclave as an environment variable.
-	       // TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
+		// and shared the details with enclave as an environment variable
+		// TODO: Enable below code after fixing Github issue https://github.com/lsds/sgx-lkl/issues/598
 		if (strcmp(filesystems[i], "ext4"))
 			continue;
 		tdev.fs_type = filesystems[i];


### PR DESCRIPTION
This patch enables the ltp test framework to use the block device
whose details are shared via the application configuration file.
the passing application configuration file via sgx-lkl command is
enabled with PR: https://github.com/lsds/sgx-lkl/pull/764.
This change enables the syncfs01 test case.

Below modifications are performed.
1. The default supported filesystem is set to ext4.
2. Disabled the formatting of block device which intern calls system() syscall.