### PR TITLE
LTP: fix test case issue sync_file_range02 issue

### DIFF
--- a/testcases/kernel/syscalls/sync_file_range/sync_file_range02.c
+++ b/testcases/kernel/syscalls/sync_file_range/sync_file_range02.c
@@ -66,8 +66,7 @@ static void verify_sync_file_range(struct testcase *tc)
 
 	SAFE_CLOSE(fd);
 
-	if ((written >= tc->exp_sync_size) &&
-	    (written <= (tc->exp_sync_size + tc->exp_sync_size/10)))
+	if (written >= tc->exp_sync_size)
 		tst_res(TPASS, "%s", tc->desc);
 	else
 		tst_res(TFAIL, "%s: Synced %li, expected %li", tc->desc,

--- a/testcases/kernel/syscalls/sync_file_range/sync_file_range02.c
+++ b/testcases/kernel/syscalls/sync_file_range/sync_file_range02.c
@@ -66,6 +66,12 @@ static void verify_sync_file_range(struct testcase *tc)
 
 	SAFE_CLOSE(fd);
 
+
+	// ext4 defers a lot of IO on a freshly made filesystem to the kernel -
+	// for example it will initialize the journal and inode tables after the
+	// mount, and this will cause extra IO.
+	// upper limit is removed based on the explanation in upstream commit
+	// 1643d850911c7d6dbf898e1e3dfeef974e84508b
 	if (written >= tc->exp_sync_size)
 		tst_res(TPASS, "%s", tc->desc);
 	else


### PR DESCRIPTION
After the PR: https://github.com/lsds/sgx-lkl/pull/764
one of the subtest cases is failing and LTP master branch
change fixes the issue. Hence, propagating the fix.

Please find below the description from the upstream commit.
Test tries to sync a range of $BYTES bytes and then make sure that
between $BYTES and $BYTES+10% was written to disk. But sometimes, more
than $BYTES+10% hit the disk: "Synced 39843840, expected 33554432" so
it failed as below.

  tst_test.c:1179: INFO: Testing on ext4
  sync_file_range02.c:74: FAIL: Sync equals write: Synced 39843840,
                          expected 33554432
  sync_file_range02.c:74: FAIL: Sync inside of write: Synced 18612224,
                          expected 16777216

From FS dev's view:

" ext4 defers a lot of IO on a freshly made filesystem to the kernel -
for example, it will initialize the journal and inode tables after the
mount and this will cause extra IO.

Creating ext4 filesystems with the options: "-E lazy_itable_init=0,
lazy_journal_init=0" might help.

Another option would be to raise the threshold. Essentially, the report
here is that the test is failing because the filesystem wrote "too much"
as a result of the sync. How much is "too much?" ..."

Let's remove the top limit of write back, and think as long as we synced
at least the expected amount, the test passes. The +10% limit seems arbitrary.