### PR TITLE
Disable test which depends on memory protection that we cannot support.

### DIFF
--- a/testcases/kernel/syscalls/send/send01.c
+++ b/testcases/kernel/syscalls/send/send01.c
@@ -103,6 +103,7 @@ static struct test_case_t tdat[] = {
 	,
 #ifndef UCLINUX
 	/* Skip since uClinux does not implement memory protection */
+#if 0 // Enable when sgx-lkl github issue 772 is fixed. Actually maybe never due to PROT_NONE not being detectable
 	{.domain = PF_INET,
 	 .type = SOCK_STREAM,
 	 .proto = 0,
@@ -115,6 +116,7 @@ static struct test_case_t tdat[] = {
 	 .cleanup = cleanup1,
 	 .desc = "invalid send buffer"}
 	,
+#endif
 #endif
 	{.domain = PF_INET,
 	 .type = SOCK_DGRAM,


### PR DESCRIPTION
Many tests construct a pointer to a block of memory which is mmap'ed as unreadable and then pass that to some syscall and expect it to fail EFAULT. lkl_access_ok cannot tell that the memory is not valid and the api call typically seg faults in a way not expected by the test.