### PR TITLE
Ken/aug14merge

### DIFF
--- a/testcases/kernel/syscalls/read/read02.c
+++ b/testcases/kernel/syscalls/read/read02.c
@@ -61,7 +61,9 @@ static struct tcase {
 	{&badfd, &bufaddr, 1, EBADF},
 	{&fd2, &bufaddr, 1, EISDIR},
 #ifndef UCLINUX
+#if 0 // See sgx-lkl issue 772 - we cannot catch protected memory regions in lkl_access_ok
 	{&fd3, &outside_buf, 1, EFAULT},
+#endif
 #endif
 	{&fd4, &addr4, 1, EINVAL},
 	{&fd4, &addr5, 4096, EINVAL},

--- a/testcases/kernel/syscalls/recv/recv01.c
+++ b/testcases/kernel/syscalls/recv/recv01.c
@@ -91,10 +91,12 @@ struct test_case_t {		/* test case structure */
 	,
 #ifndef UCLINUX
 	    /* Skip since uClinux does not implement memory protection */
+#if 0 // See sgx-lkl issue 772 - we cannot catch protected memory regions in lkl_access_ok
 	{
 	PF_INET, SOCK_STREAM, 0, (void *)-1, sizeof(buf), 0,
 		    -1, EFAULT, setup1, cleanup1, "invalid recv buffer"}
 	,
+#endif
 #endif
 	{
 	PF_INET, SOCK_STREAM, 0, buf, sizeof(buf), MSG_OOB,

--- a/testcases/kernel/syscalls/setsockopt/setsockopt01.c
+++ b/testcases/kernel/syscalls/setsockopt/setsockopt01.c
@@ -94,12 +94,14 @@ struct test_case_t {		/* test case structure */
 		    "bad file descriptor"}
 	,
 #if !defined(UCLINUX)
+#if 0 // See sgx-lkl issue 772 - we cannot catch protected memory regions in lkl_access_ok
 	{
 	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, 0,
 		    sizeof(optval), (struct sockaddr *)&fsin1,
 		    sizeof(fsin1), -1, EFAULT, setup1, cleanup1,
 		    "invalid option buffer"}
 	,
+#endif
 #endif
 	{
 	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,


### PR DESCRIPTION
Merge Ken's changes relating to 772/279/169 now wrapped into https://github.com/lsds/sgx-lkl/issues/787 with the current state of ltp used by sgx-lkl as of 14th August at commit fdbc19e77a1af7a01553bd98faf3537254c4ea30 in sgx-lkl, iie ab1e56249de46e5ca09c9d8f80bf34b86ae40101 in ltp

This should include as many of the available fixes as possible. There are some (5) failures which I will disable for now in sgx-lkl's list of disabled tests:

batch 1: (both timeouts)
-#/ltp/testcases/kernel/syscalls/gettimeofday/gettimeofday02
-#/ltp/testcases/kernel/syscalls/mmap/mmap11

batch 2:
-#/ltp/testcases/kernel/syscalls/futex/futex_cmp_requeue01
-#/ltp/testcases/kernel/syscalls/getcwd/getcwd04
-#/ltp/testcases/kernel/syscalls/send/send01
