### PR TITLE
Fix compilation error in write05.c

### DIFF
--- a/testcases/kernel/syscalls/write/write05.c
+++ b/testcases/kernel/syscalls/write/write05.c
@@ -82,8 +82,7 @@ static void setup(void)
 {
 	fd = SAFE_OPEN("write_test", O_RDWR | O_CREAT, 0644);
 
-	bad_addr = SAFE_MMAP(0, 1, PROT_NONE
-						MAP_PRIVATE | MAP_ANONY	MOUS, 0, 0);
+	bad_addr = SAFE_MMAP(0, 1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
 
 	SAFE_PIPE(pipefd);
 	SAFE_CLOSE(pipefd[0]);


### PR DESCRIPTION
This was causing the enabled test to not run.