### PR TITLE
Fixing 6 LTP test build errors

### DIFF
--- a/testcases/kernel/syscalls/chroot/chroot03.c
+++ b/testcases/kernel/syscalls/chroot/chroot03.c
@@ -84,8 +84,7 @@ struct test_case_t {
 	     * attempt to chroot to a path pointing to an invalid address
 	     * and expect EFAULT as errno
 	     */
-	{
-//	(char *)-1, EFAULT}, Enable when sgx-lkl github issue 772 is fixed.
+//	{(char *)-1, EFAULT}, Enable when sgx-lkl github issue 772 is fixed.
 #endif
 	{symbolic_dir, ELOOP}
 };

--- a/testcases/kernel/syscalls/connect/connect01.c
+++ b/testcases/kernel/syscalls/connect/connect01.c
@@ -94,6 +94,7 @@ struct test_case_t {		/* test case structure */
 		    cleanup1, "invalid socket buffer"},
 #endif
 	
+	{
 	PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&sin1,
 		    3, -1, EINVAL, setup1, cleanup1, "invalid salen"}, {
 	0, 0, 0, (struct sockaddr *)&sin1,

--- a/testcases/kernel/syscalls/fstat/fstat03.c
+++ b/testcases/kernel/syscalls/fstat/fstat03.c
@@ -33,7 +33,7 @@ static struct tcase {
 	struct stat *stat_buf;
 	int exp_err;
 } tcases[] = {
-	{&fd_ebadf, &stat_buf, EBADF}
+	{&fd_ebadf, &stat_buf, EBADF},
 	{&fd_ok, NULL, EFAULT},
 };
 

--- a/testcases/kernel/syscalls/ptrace/ptrace06.c
+++ b/testcases/kernel/syscalls/ptrace/ptrace06.c
@@ -22,7 +22,6 @@
 
 #include "test.h"
 #include "spawn_ptrace_child.h"
-#include "config.h"
 
 /* this should be sizeof(struct user), but that info is only found
  * in the kernel asm/user.h which is not exported to userspace.

--- a/testcases/kernel/syscalls/ptrace/ptrace07.c
+++ b/testcases/kernel/syscalls/ptrace/ptrace07.c
@@ -31,8 +31,8 @@
 #include <stdlib.h>
 #include <sys/uio.h>
 #include <sys/wait.h>
+#include <config.h>
 
-#include "config.h"
 #include "ptrace.h"
 #include "tst_test.h"
 

--- a/testcases/kernel/syscalls/write/write05.c
+++ b/testcases/kernel/syscalls/write/write05.c
@@ -87,7 +87,7 @@ static void setup(void)
 	// Once #787 is addressed, this should be able to be switched back.
 	// In the meantime using SAFE_MMAP will fail for reasons unrelated to this test.
 	//bad_addr = SAFE_MMAP(0, 1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
-	bad_addr = 0
+	bad_addr = 0;
 		
 	SAFE_PIPE(pipefd);
 	SAFE_CLOSE(pipefd[0]);


### PR DESCRIPTION
I was investigating ltp build errors and found build errors for these 6 tests and fixed.
- connect01
- fstat03
- write05
- chroot03
- ptrace06 & ptrace07

Also verified that connect01, fstat03, write05, chroot03 are enabled tests but they are not reported failed evenif their binaries failed to build.  They are not reported at all. So there is a bug in ltp test runner script that if ltp test binary is not available (not built successfully) , it is not reported as failure. I will investigate and submit a PR to fix that to lsds/sgx-lkl.

After we merge this PR and bump ltp submodule in sgx-lkl, these 4 tests will be reported pass. 

cc @SeanTAllen @KenGordon @paulcallen @bodzhang @davidchisnall 
